### PR TITLE
Use auto-generated notes for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,5 +132,5 @@ jobs:
         # Create release with artifacts
         gh release create "$TAG" \
           --title "Release $VERSION" \
-          --notes "Automated release for version $VERSION" \
+          --generate-notes \
           "${files[@]}"


### PR DESCRIPTION
## Summary
- switch release creation from static --notes to --generate-notes
- keep existing tag and artifact safety checks unchanged

## Why
- make GitHub Release descriptions auto-generated from merged changes