### PR TITLE
Fix packaged app name and include java.net.http

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -64,11 +64,13 @@ compose.desktop {
 
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
-            packageName = "io.github.hayatoyagi.prvisualizer"
+            packageName = "GitHubPRsVisualizer"
             packageVersion = appVersion
+            modules("java.net.http")
 
             // Application icon configuration
             macOS {
+                bundleID = "io.github.hayatoyagi.prvisualizer"
                 iconFile.set(project.file("src/jvmMain/resources/icon.icns"))
             }
             windows {


### PR DESCRIPTION
## Summary
- include `java.net.http` in desktop native distribution modules
- change package name to `GitHubPRsVisualizer` so the app bundle name is user-friendly
- keep macOS bundle id as `io.github.hayatoyagi.prvisualizer`

## Why
- fix runtime error showing `java/net/http/HttpClient`
- avoid installing app as `io.github.hayatoyagi.prvisualizer.app`